### PR TITLE
Filter pinterest images by aspect ratio

### DIFF
--- a/pinterest-aspect-ratio-filter/.gitignore
+++ b/pinterest-aspect-ratio-filter/.gitignore
@@ -1,0 +1,34 @@
+# Dependencies
+node_modules/
+
+# System files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Temporary files
+*.tmp
+*.temp
+.tmp/
+
+# Logs
+*.log
+npm-debug.log*
+
+# Build output (if any future build process is added)
+dist/
+build/
+
+# Chrome extension development
+*.pem
+*.crx
+*.zip
+
+# Environment files
+.env
+.env.local

--- a/pinterest-aspect-ratio-filter/README.md
+++ b/pinterest-aspect-ratio-filter/README.md
@@ -1,0 +1,125 @@
+# Pinterest Aspect Ratio Filter - Chrome Extension
+
+A Chrome extension that filters Pinterest images based on their aspect ratios. Perfect for finding images with specific dimensions like YouTube thumbnails (16:9), square images (1:1), or portrait images (9:16).
+
+## Features
+
+- **Real-time Filtering**: Automatically filters images as you browse Pinterest (feed, search results, boards)
+- **Multiple Filter Modes**:
+  - **Hide**: Completely removes non-matching images
+  - **Blur**: Blurs non-matching images with a lock icon
+  - **Dim**: Dims non-matching images with a "Filtered" label
+- **Preset Aspect Ratios**:
+  - 16:9 (YouTube/Widescreen)
+  - 4:3 (Traditional TV)
+  - 1:1 (Square)
+  - 4:5 (Instagram Portrait)
+  - 9:16 (Stories/Reels)
+  - 2:3 (Pinterest Standard)
+  - 3:4 (Portrait)
+  - 5:4 (Medium Format)
+- **Custom Ratios**: Add your own custom aspect ratios
+- **Tolerance Control**: Adjust tolerance (0-20%) for slight variations in aspect ratios
+- **Easy Toggle**: Quickly enable/disable filtering
+
+## Installation
+
+### Developer Mode Installation (Recommended for Testing)
+
+1. **Download the Extension**
+   - Clone or download this repository to your local machine
+
+2. **Open Chrome Extensions Page**
+   - Open Chrome browser
+   - Navigate to `chrome://extensions/`
+   - Or go to Menu → More Tools → Extensions
+
+3. **Enable Developer Mode**
+   - Toggle the "Developer mode" switch in the top-right corner
+
+4. **Load the Extension**
+   - Click "Load unpacked"
+   - Select the `pinterest-aspect-ratio-filter` folder
+   - The extension will appear in your extensions list
+
+5. **Pin the Extension** (Optional)
+   - Click the puzzle piece icon in Chrome's toolbar
+   - Click the pin icon next to "Pinterest Aspect Ratio Filter"
+
+## Usage
+
+1. **Open Pinterest**
+   - Navigate to any Pinterest page (pinterest.com)
+
+2. **Configure Filters**
+   - Click the extension icon in your toolbar
+   - Select your preferred filter mode (Hide/Blur/Dim)
+   - Check the aspect ratios you want to allow
+   - Adjust tolerance if needed
+
+3. **Add Custom Ratios** (Optional)
+   - Enter width and height values
+   - Click "Add" to create a custom ratio
+   - Your custom ratios will be saved
+
+4. **Browse Pinterest**
+   - The extension automatically filters images based on your settings
+   - Images matching your selected ratios will be shown normally
+   - Non-matching images will be hidden, blurred, or dimmed
+
+5. **Toggle On/Off**
+   - Use the "Filter Active/Inactive" button to quickly enable/disable filtering
+
+## How It Works
+
+The extension:
+1. Detects all images on Pinterest pages
+2. Calculates each image's aspect ratio (width ÷ height)
+3. Compares against your selected ratios (with tolerance)
+4. Applies the chosen filter mode to non-matching images
+5. Continuously monitors for new images as you scroll
+
+## Permissions
+
+The extension requires:
+- **Access to pinterest.com**: To detect and filter images
+- **Storage**: To save your filter preferences
+
+## Tips
+
+- **Tolerance**: Set a higher tolerance (10-15%) if you want to be less strict about exact ratios
+- **Multiple Ratios**: Select multiple ratios to see a variety of image formats
+- **Custom Ratios**: Use custom ratios for specific project requirements
+- **Performance**: The "Hide" mode provides the best performance as it removes elements from the page
+
+## Troubleshooting
+
+**Images not filtering:**
+- Refresh the Pinterest page after changing settings
+- Make sure the filter is active (green toggle button)
+- Check that you have at least one aspect ratio selected
+
+**Extension not working:**
+- Ensure you're on pinterest.com
+- Try reloading the extension from chrome://extensions/
+- Clear browser cache and reload Pinterest
+
+**Custom ratios not saving:**
+- Make sure to enter valid positive numbers
+- Click "Save Settings" after adding custom ratios
+
+## Privacy
+
+This extension:
+- Works entirely locally in your browser
+- Does not collect or transmit any data
+- Only accesses Pinterest pages when you visit them
+- Stores settings locally in Chrome's sync storage
+
+## Support
+
+For issues or feature requests, please create an issue in the repository.
+
+## License
+
+MIT License - Feel free to modify and distribute as needed.

--- a/pinterest-aspect-ratio-filter/background.js
+++ b/pinterest-aspect-ratio-filter/background.js
@@ -1,0 +1,53 @@
+// Background service worker for Pinterest Aspect Ratio Filter
+
+// Handle extension installation
+chrome.runtime.onInstalled.addListener(() => {
+    // Set default settings on first install
+    chrome.storage.sync.get(['allowedRatios'], (result) => {
+        if (!result.allowedRatios) {
+            chrome.storage.sync.set({
+                filterMode: 'hide',
+                allowedRatios: [],
+                customRatios: [],
+                tolerance: 5,
+                filterActive: true
+            });
+        }
+    });
+});
+
+// Handle tab updates to inject content script if needed
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (changeInfo.status === 'complete' && tab.url && tab.url.includes('pinterest.com')) {
+        // Content script should auto-inject based on manifest, but this ensures it's loaded
+        chrome.tabs.sendMessage(tabId, { action: 'ping' }, (response) => {
+            if (chrome.runtime.lastError) {
+                // Content script not loaded, inject it
+                chrome.scripting.executeScript({
+                    target: { tabId: tabId },
+                    files: ['content.js']
+                });
+                chrome.scripting.insertCSS({
+                    target: { tabId: tabId },
+                    files: ['content.css']
+                });
+            }
+        });
+    }
+});
+
+// Handle messages from content scripts
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.action === 'getSettings') {
+        chrome.storage.sync.get({
+            filterMode: 'hide',
+            allowedRatios: [],
+            customRatios: [],
+            tolerance: 5,
+            filterActive: true
+        }, (settings) => {
+            sendResponse(settings);
+        });
+        return true; // Keep message channel open for async response
+    }
+});

--- a/pinterest-aspect-ratio-filter/content.css
+++ b/pinterest-aspect-ratio-filter/content.css
@@ -1,0 +1,94 @@
+/* Content Script Styles for Pinterest Aspect Ratio Filter */
+
+/* Hide filter */
+.parf-hide {
+    display: none !important;
+}
+
+/* Blur filter */
+.parf-blur {
+    filter: blur(15px) !important;
+    transition: filter 0.3s ease !important;
+    position: relative !important;
+    overflow: hidden !important;
+}
+
+.parf-blur::after {
+    content: "🔒" !important;
+    position: absolute !important;
+    top: 50% !important;
+    left: 50% !important;
+    transform: translate(-50%, -50%) !important;
+    font-size: 24px !important;
+    z-index: 10 !important;
+    background: rgba(255, 255, 255, 0.9) !important;
+    width: 40px !important;
+    height: 40px !important;
+    border-radius: 50% !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
+}
+
+.parf-blur:hover {
+    filter: blur(5px) !important;
+}
+
+/* Dim filter */
+.parf-dim {
+    opacity: 0.15 !important;
+    transition: opacity 0.3s ease !important;
+    position: relative !important;
+}
+
+.parf-dim::after {
+    content: "Filtered" !important;
+    position: absolute !important;
+    top: 10px !important;
+    right: 10px !important;
+    background: rgba(0, 0, 0, 0.7) !important;
+    color: white !important;
+    padding: 4px 8px !important;
+    border-radius: 4px !important;
+    font-size: 11px !important;
+    font-weight: 600 !important;
+    z-index: 10 !important;
+    pointer-events: none !important;
+    text-transform: uppercase !important;
+    letter-spacing: 0.5px !important;
+}
+
+.parf-dim:hover {
+    opacity: 0.5 !important;
+}
+
+/* Ensure filtered elements maintain their layout space when dimmed or blurred */
+[data-parf-filtered="true"] {
+    min-height: 100px !important;
+    min-width: 100px !important;
+}
+
+/* Animation for filter application */
+@keyframes parfFilterApply {
+    from {
+        transform: scale(1);
+    }
+    to {
+        transform: scale(0.98);
+    }
+}
+
+/* Special handling for Pinterest grid items to prevent layout shifts */
+[data-grid-item][data-parf-filtered="true"].parf-hide {
+    visibility: hidden !important;
+    height: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: hidden !important;
+}
+
+/* Smooth transitions when filters are applied/removed */
+[data-parf-filtered] {
+    transition: all 0.3s ease !important;
+}

--- a/pinterest-aspect-ratio-filter/content.js
+++ b/pinterest-aspect-ratio-filter/content.js
@@ -1,0 +1,316 @@
+// Pinterest Aspect Ratio Filter Content Script
+
+let settings = {
+    filterMode: 'hide',
+    allowedRatios: [],
+    tolerance: 5,
+    filterActive: true
+};
+
+let processedImages = new WeakSet();
+let observer = null;
+
+// Initialize
+(async function init() {
+    // Load settings
+    await loadSettings();
+    
+    // Start filtering if active
+    if (settings.filterActive) {
+        startFiltering();
+    }
+
+    // Listen for messages from popup
+    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+        if (request.action === 'updateSettings') {
+            settings = request.settings;
+            applyFilters();
+        } else if (request.action === 'toggleFilter') {
+            settings.filterActive = request.active;
+            if (settings.filterActive) {
+                startFiltering();
+            } else {
+                stopFiltering();
+            }
+        }
+    });
+})();
+
+// Load settings from storage
+async function loadSettings() {
+    return new Promise((resolve) => {
+        chrome.storage.sync.get({
+            filterMode: 'hide',
+            allowedRatios: [],
+            tolerance: 5,
+            filterActive: true
+        }, (result) => {
+            settings = result;
+            resolve();
+        });
+    });
+}
+
+// Start filtering
+function startFiltering() {
+    // Initial filter application
+    applyFilters();
+    
+    // Setup mutation observer for dynamic content
+    if (!observer) {
+        observer = new MutationObserver((mutations) => {
+            let hasNewImages = false;
+            
+            mutations.forEach((mutation) => {
+                if (mutation.type === 'childList') {
+                    mutation.addedNodes.forEach((node) => {
+                        if (node.nodeType === Node.ELEMENT_NODE) {
+                            if (node.tagName === 'IMG' || node.querySelector('img')) {
+                                hasNewImages = true;
+                            }
+                        }
+                    });
+                }
+            });
+            
+            if (hasNewImages) {
+                setTimeout(applyFilters, 100); // Small delay to ensure images are loaded
+            }
+        });
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    }
+}
+
+// Stop filtering
+function stopFiltering() {
+    if (observer) {
+        observer.disconnect();
+        observer = null;
+    }
+    removeAllFilters();
+}
+
+// Apply filters to all images
+function applyFilters() {
+    if (!settings.filterActive) return;
+    
+    // Find all Pinterest images
+    const images = findPinterestImages();
+    
+    images.forEach(img => {
+        filterImage(img);
+    });
+}
+
+// Find Pinterest images
+function findPinterestImages() {
+    const images = [];
+    
+    // Standard image tags
+    document.querySelectorAll('img').forEach(img => {
+        if (isPinterestImage(img)) {
+            images.push(img);
+        }
+    });
+    
+    // Background images in divs (Pinterest often uses these)
+    document.querySelectorAll('[style*="background-image"]').forEach(elem => {
+        const bgImage = elem.style.backgroundImage;
+        if (bgImage && bgImage.includes('pinimg.com')) {
+            images.push(elem);
+        }
+    });
+    
+    // Pinterest specific image containers
+    document.querySelectorAll('[data-test-id*="pin"], [data-test-id*="image"], .GrowthUnauthPinImage, [role="img"]').forEach(elem => {
+        const img = elem.querySelector('img') || elem;
+        if (img && !images.includes(img)) {
+            images.push(img);
+        }
+    });
+    
+    return images;
+}
+
+// Check if element is a Pinterest image
+function isPinterestImage(elem) {
+    if (!elem) return false;
+    
+    // Check src for img tags
+    if (elem.tagName === 'IMG' && elem.src) {
+        return elem.src.includes('pinimg.com') || 
+               elem.src.includes('pinterest') ||
+               elem.closest('[data-test-id*="pin"]') !== null;
+    }
+    
+    // Check background image for divs
+    if (elem.style.backgroundImage) {
+        return elem.style.backgroundImage.includes('pinimg.com');
+    }
+    
+    return false;
+}
+
+// Filter individual image
+function filterImage(element) {
+    // Skip if already processed recently
+    if (processedImages.has(element)) {
+        return;
+    }
+    
+    // Get image dimensions
+    const dimensions = getImageDimensions(element);
+    if (!dimensions || dimensions.width === 0 || dimensions.height === 0) {
+        // Try again later if dimensions not available
+        setTimeout(() => {
+            processedImages.delete(element);
+            filterImage(element);
+        }, 500);
+        return;
+    }
+    
+    // Calculate aspect ratio
+    const aspectRatio = dimensions.width / dimensions.height;
+    
+    // Check if ratio is allowed
+    const isAllowed = isRatioAllowed(aspectRatio);
+    
+    // Apply or remove filter based on result
+    if (!isAllowed) {
+        applyFilterToElement(element);
+    } else {
+        removeFilterFromElement(element);
+    }
+    
+    // Mark as processed
+    processedImages.add(element);
+}
+
+// Get image dimensions
+function getImageDimensions(element) {
+    if (element.tagName === 'IMG') {
+        // For img tags, use natural dimensions if available
+        if (element.naturalWidth && element.naturalHeight) {
+            return {
+                width: element.naturalWidth,
+                height: element.naturalHeight
+            };
+        } else if (element.width && element.height) {
+            return {
+                width: element.width,
+                height: element.height
+            };
+        }
+    }
+    
+    // For background images or when natural dimensions aren't available
+    const rect = element.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+        return {
+            width: rect.width,
+            height: rect.height
+        };
+    }
+    
+    return null;
+}
+
+// Check if aspect ratio is allowed
+function isRatioAllowed(ratio) {
+    if (settings.allowedRatios.length === 0) {
+        return true; // If no ratios selected, allow all
+    }
+    
+    const tolerance = settings.tolerance / 100;
+    
+    return settings.allowedRatios.some(allowedRatio => {
+        const minRatio = allowedRatio * (1 - tolerance);
+        const maxRatio = allowedRatio * (1 + tolerance);
+        return ratio >= minRatio && ratio <= maxRatio;
+    });
+}
+
+// Apply filter to element
+function applyFilterToElement(element) {
+    // Find the container to apply filter to
+    const container = findImageContainer(element);
+    const target = container || element;
+    
+    // Remove any existing filter classes
+    target.classList.remove('parf-hide', 'parf-blur', 'parf-dim');
+    
+    // Apply new filter based on mode
+    switch (settings.filterMode) {
+        case 'hide':
+            target.classList.add('parf-hide');
+            break;
+        case 'blur':
+            target.classList.add('parf-blur');
+            break;
+        case 'dim':
+            target.classList.add('parf-dim');
+            break;
+    }
+    
+    target.setAttribute('data-parf-filtered', 'true');
+}
+
+// Remove filter from element
+function removeFilterFromElement(element) {
+    const container = findImageContainer(element);
+    const target = container || element;
+    
+    target.classList.remove('parf-hide', 'parf-blur', 'parf-dim');
+    target.removeAttribute('data-parf-filtered');
+}
+
+// Find the appropriate container for an image
+function findImageContainer(element) {
+    // Look for Pinterest pin containers
+    const pinContainer = element.closest('[data-test-id*="pin"], [data-grid-item], .GrowthUnauthPinContainer');
+    if (pinContainer) {
+        return pinContainer;
+    }
+    
+    // Look for general image containers
+    const imageContainer = element.closest('[role="img"], .imgContainer, .imageWrapper');
+    if (imageContainer) {
+        return imageContainer;
+    }
+    
+    // Look for link containers (pins are often wrapped in links)
+    const linkContainer = element.closest('a[href*="/pin/"]');
+    if (linkContainer) {
+        return linkContainer;
+    }
+    
+    return null;
+}
+
+// Remove all filters
+function removeAllFilters() {
+    document.querySelectorAll('[data-parf-filtered]').forEach(element => {
+        element.classList.remove('parf-hide', 'parf-blur', 'parf-dim');
+        element.removeAttribute('data-parf-filtered');
+    });
+    processedImages = new WeakSet();
+}
+
+// Reprocess images when window resizes (dimensions might change)
+let resizeTimeout;
+window.addEventListener('resize', () => {
+    clearTimeout(resizeTimeout);
+    resizeTimeout = setTimeout(() => {
+        processedImages = new WeakSet();
+        applyFilters();
+    }, 500);
+});
+
+// Reprocess when images load
+window.addEventListener('load', () => {
+    setTimeout(applyFilters, 1000);
+});

--- a/pinterest-aspect-ratio-filter/icon.svg
+++ b/pinterest-aspect-ratio-filter/icon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background -->
+  <rect width="128" height="128" rx="16" fill="url(#bg)"/>
+  
+  <!-- Main rectangle (aspect ratio container) -->
+  <rect x="24" y="40" width="80" height="48" rx="4" fill="white" opacity="0.95"/>
+  
+  <!-- Vertical dividers showing aspect ratio -->
+  <line x1="50" y1="40" x2="50" y2="88" stroke="#667eea" stroke-width="2" opacity="0.6"/>
+  <line x1="78" y1="40" x2="78" y2="88" stroke="#667eea" stroke-width="2" opacity="0.6"/>
+  
+  <!-- Small indicator rectangles -->
+  <rect x="28" y="44" width="18" height="18" fill="#667eea" opacity="0.3" rx="2"/>
+  <rect x="54" y="44" width="20" height="12" fill="#764ba2" opacity="0.3" rx="2"/>
+  <rect x="82" y="44" width="18" height="24" fill="#667eea" opacity="0.3" rx="2"/>
+</svg>

--- a/pinterest-aspect-ratio-filter/icon128.png
+++ b/pinterest-aspect-ratio-filter/icon128.png
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background -->
+  <rect width="128" height="128" rx="16" fill="url(#bg)"/>
+  
+  <!-- Main rectangle (aspect ratio container) -->
+  <rect x="24" y="40" width="80" height="48" rx="4" fill="white" opacity="0.95"/>
+  
+  <!-- Vertical dividers showing aspect ratio -->
+  <line x1="50" y1="40" x2="50" y2="88" stroke="#667eea" stroke-width="2" opacity="0.6"/>
+  <line x1="78" y1="40" x2="78" y2="88" stroke="#667eea" stroke-width="2" opacity="0.6"/>
+  
+  <!-- Small indicator rectangles -->
+  <rect x="28" y="44" width="18" height="18" fill="#667eea" opacity="0.3" rx="2"/>
+  <rect x="54" y="44" width="20" height="12" fill="#764ba2" opacity="0.3" rx="2"/>
+  <rect x="82" y="44" width="18" height="24" fill="#667eea" opacity="0.3" rx="2"/>
+</svg>

--- a/pinterest-aspect-ratio-filter/icon16.png
+++ b/pinterest-aspect-ratio-filter/icon16.png
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background -->
+  <rect width="128" height="128" rx="16" fill="url(#bg)"/>
+  
+  <!-- Main rectangle (aspect ratio container) -->
+  <rect x="24" y="40" width="80" height="48" rx="4" fill="white" opacity="0.95"/>
+  
+  <!-- Vertical dividers showing aspect ratio -->
+  <line x1="50" y1="40" x2="50" y2="88" stroke="#667eea" stroke-width="2" opacity="0.6"/>
+  <line x1="78" y1="40" x2="78" y2="88" stroke="#667eea" stroke-width="2" opacity="0.6"/>
+  
+  <!-- Small indicator rectangles -->
+  <rect x="28" y="44" width="18" height="18" fill="#667eea" opacity="0.3" rx="2"/>
+  <rect x="54" y="44" width="20" height="12" fill="#764ba2" opacity="0.3" rx="2"/>
+  <rect x="82" y="44" width="18" height="24" fill="#667eea" opacity="0.3" rx="2"/>
+</svg>

--- a/pinterest-aspect-ratio-filter/icon48.png
+++ b/pinterest-aspect-ratio-filter/icon48.png
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Background -->
+  <rect width="128" height="128" rx="16" fill="url(#bg)"/>
+  
+  <!-- Main rectangle (aspect ratio container) -->
+  <rect x="24" y="40" width="80" height="48" rx="4" fill="white" opacity="0.95"/>
+  
+  <!-- Vertical dividers showing aspect ratio -->
+  <line x1="50" y1="40" x2="50" y2="88" stroke="#667eea" stroke-width="2" opacity="0.6"/>
+  <line x1="78" y1="40" x2="78" y2="88" stroke="#667eea" stroke-width="2" opacity="0.6"/>
+  
+  <!-- Small indicator rectangles -->
+  <rect x="28" y="44" width="18" height="18" fill="#667eea" opacity="0.3" rx="2"/>
+  <rect x="54" y="44" width="20" height="12" fill="#764ba2" opacity="0.3" rx="2"/>
+  <rect x="82" y="44" width="18" height="24" fill="#667eea" opacity="0.3" rx="2"/>
+</svg>

--- a/pinterest-aspect-ratio-filter/manifest.json
+++ b/pinterest-aspect-ratio-filter/manifest.json
@@ -1,0 +1,40 @@
+{
+  "manifest_version": 3,
+  "name": "Pinterest Aspect Ratio Filter",
+  "version": "1.0.0",
+  "description": "Filter Pinterest images by aspect ratio (16:9, 1:1, 9:16, etc.)",
+  "permissions": [
+    "storage",
+    "activeTab"
+  ],
+  "host_permissions": [
+    "*://*.pinterest.com/*",
+    "*://*.pinimg.com/*"
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icon16.png",
+      "48": "icon48.png",
+      "128": "icon128.png"
+    }
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*.pinterest.com/*"
+      ],
+      "js": ["content.js"],
+      "css": ["content.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "icons": {
+    "16": "icon16.png",
+    "48": "icon48.png",
+    "128": "icon128.png"
+  }
+}

--- a/pinterest-aspect-ratio-filter/popup.css
+++ b/pinterest-aspect-ratio-filter/popup.css
@@ -1,0 +1,336 @@
+/* Popup Styles */
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    width: 400px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: #333;
+}
+
+.container {
+    background: white;
+    min-height: 500px;
+    display: flex;
+    flex-direction: column;
+}
+
+h1 {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    padding: 20px;
+    font-size: 18px;
+    font-weight: 600;
+    text-align: center;
+    margin: 0;
+}
+
+h2 {
+    font-size: 14px;
+    font-weight: 600;
+    color: #555;
+    margin-bottom: 12px;
+    padding-bottom: 8px;
+    border-bottom: 2px solid #f0f0f0;
+}
+
+h3 {
+    font-size: 12px;
+    font-weight: 600;
+    color: #666;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.filter-section,
+.ratio-section,
+.tolerance-section {
+    padding: 20px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+/* Filter Mode */
+.filter-mode {
+    display: flex;
+    gap: 15px;
+    justify-content: center;
+}
+
+.filter-mode label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    padding: 8px 16px;
+    border: 2px solid #e0e0e0;
+    border-radius: 20px;
+    transition: all 0.3s ease;
+}
+
+.filter-mode label:hover {
+    border-color: #667eea;
+    background: #f8f9ff;
+}
+
+.filter-mode input[type="radio"] {
+    margin-right: 6px;
+}
+
+.filter-mode input[type="radio"]:checked + span {
+    font-weight: 600;
+    color: #667eea;
+}
+
+/* Ratio Options */
+.preset-ratios {
+    margin-bottom: 20px;
+}
+
+.ratio-option {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+    margin-bottom: 6px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.ratio-option:hover {
+    background: #f8f9ff;
+}
+
+.ratio-option input[type="checkbox"] {
+    margin-right: 10px;
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+}
+
+.ratio-option span {
+    font-size: 13px;
+    color: #444;
+}
+
+/* Custom Ratio */
+.custom-ratio {
+    margin-top: 15px;
+    padding-top: 15px;
+    border-top: 1px solid #f0f0f0;
+}
+
+.custom-input {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.custom-input input[type="number"] {
+    width: 70px;
+    padding: 6px 10px;
+    border: 2px solid #e0e0e0;
+    border-radius: 6px;
+    font-size: 13px;
+    transition: border-color 0.3s ease;
+}
+
+.custom-input input[type="number"]:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+.custom-input span {
+    font-weight: 600;
+    color: #666;
+}
+
+#addCustom {
+    padding: 6px 16px;
+    background: #667eea;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.3s ease;
+}
+
+#addCustom:hover {
+    background: #5a67d8;
+}
+
+/* Custom Ratios List */
+.custom-ratio-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 6px;
+}
+
+.custom-ratio-item .ratio-option {
+    flex: 1;
+    margin-bottom: 0;
+}
+
+.remove-btn {
+    width: 24px;
+    height: 24px;
+    border: none;
+    background: #ff4444;
+    color: white;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.3s ease;
+}
+
+.remove-btn:hover {
+    background: #cc0000;
+}
+
+/* Tolerance */
+.tolerance-control {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+#tolerance {
+    flex: 1;
+    height: 6px;
+    border-radius: 3px;
+    background: #e0e0e0;
+    outline: none;
+    -webkit-appearance: none;
+}
+
+#tolerance::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #667eea;
+    cursor: pointer;
+    transition: background 0.3s ease;
+}
+
+#tolerance::-webkit-slider-thumb:hover {
+    background: #5a67d8;
+}
+
+#toleranceValue {
+    min-width: 35px;
+    font-weight: 600;
+    color: #667eea;
+}
+
+.tolerance-hint {
+    font-size: 11px;
+    color: #888;
+    margin-top: 8px;
+}
+
+/* Controls */
+.controls {
+    padding: 20px;
+    display: flex;
+    gap: 12px;
+    background: #f8f9ff;
+}
+
+.toggle-btn,
+.save-btn {
+    flex: 1;
+    padding: 12px;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.toggle-btn {
+    background: #e0e0e0;
+    color: #666;
+}
+
+.toggle-btn.active {
+    background: #4caf50;
+    color: white;
+}
+
+.toggle-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.save-btn {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+}
+
+.save-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+}
+
+/* Status */
+.status {
+    padding: 12px 20px;
+    text-align: center;
+    font-size: 13px;
+    font-weight: 500;
+    display: none;
+    animation: slideIn 0.3s ease;
+}
+
+.status.success {
+    background: #d4edda;
+    color: #155724;
+}
+
+.status.error {
+    background: #f8d7da;
+    color: #721c24;
+}
+
+@keyframes slideIn {
+    from {
+        transform: translateY(-20px);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: #f1f1f1;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #888;
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: #555;
+}

--- a/pinterest-aspect-ratio-filter/popup.html
+++ b/pinterest-aspect-ratio-filter/popup.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pinterest Aspect Ratio Filter</title>
+    <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Pinterest Aspect Ratio Filter</h1>
+        
+        <div class="filter-section">
+            <h2>Filter Mode</h2>
+            <div class="filter-mode">
+                <label>
+                    <input type="radio" name="filterMode" value="hide" checked>
+                    <span>Hide</span>
+                </label>
+                <label>
+                    <input type="radio" name="filterMode" value="blur">
+                    <span>Blur</span>
+                </label>
+                <label>
+                    <input type="radio" name="filterMode" value="dim">
+                    <span>Dim</span>
+                </label>
+            </div>
+        </div>
+
+        <div class="ratio-section">
+            <h2>Allowed Aspect Ratios</h2>
+            
+            <div class="preset-ratios">
+                <h3>Common Ratios</h3>
+                <label class="ratio-option">
+                    <input type="checkbox" data-ratio="16:9" data-value="1.778">
+                    <span>16:9 (YouTube/Widescreen)</span>
+                </label>
+                <label class="ratio-option">
+                    <input type="checkbox" data-ratio="4:3" data-value="1.333">
+                    <span>4:3 (Traditional TV)</span>
+                </label>
+                <label class="ratio-option">
+                    <input type="checkbox" data-ratio="1:1" data-value="1">
+                    <span>1:1 (Square)</span>
+                </label>
+                <label class="ratio-option">
+                    <input type="checkbox" data-ratio="4:5" data-value="0.8">
+                    <span>4:5 (Instagram Portrait)</span>
+                </label>
+                <label class="ratio-option">
+                    <input type="checkbox" data-ratio="9:16" data-value="0.563">
+                    <span>9:16 (Stories/Reels)</span>
+                </label>
+                <label class="ratio-option">
+                    <input type="checkbox" data-ratio="2:3" data-value="0.667">
+                    <span>2:3 (Pinterest Standard)</span>
+                </label>
+                <label class="ratio-option">
+                    <input type="checkbox" data-ratio="3:4" data-value="0.75">
+                    <span>3:4 (Portrait)</span>
+                </label>
+                <label class="ratio-option">
+                    <input type="checkbox" data-ratio="5:4" data-value="1.25">
+                    <span>5:4 (Medium Format)</span>
+                </label>
+            </div>
+
+            <div class="custom-ratio">
+                <h3>Custom Ratio</h3>
+                <div class="custom-input">
+                    <input type="number" id="customWidth" placeholder="Width" min="1" max="100">
+                    <span>:</span>
+                    <input type="number" id="customHeight" placeholder="Height" min="1" max="100">
+                    <button id="addCustom">Add</button>
+                </div>
+                <div id="customRatiosList"></div>
+            </div>
+        </div>
+
+        <div class="tolerance-section">
+            <h2>Tolerance</h2>
+            <div class="tolerance-control">
+                <input type="range" id="tolerance" min="0" max="20" value="5" step="1">
+                <span id="toleranceValue">5%</span>
+            </div>
+            <p class="tolerance-hint">Allow slight variations in aspect ratio</p>
+        </div>
+
+        <div class="controls">
+            <button id="toggleFilter" class="toggle-btn active">Filter Active</button>
+            <button id="saveSettings" class="save-btn">Save Settings</button>
+        </div>
+
+        <div class="status" id="status"></div>
+    </div>
+    <script src="popup.js"></script>
+</body>
+</html>

--- a/pinterest-aspect-ratio-filter/popup.js
+++ b/pinterest-aspect-ratio-filter/popup.js
@@ -1,0 +1,226 @@
+// Initialize popup
+document.addEventListener('DOMContentLoaded', async () => {
+    await loadSettings();
+    setupEventListeners();
+});
+
+// Load saved settings
+async function loadSettings() {
+    const settings = await chrome.storage.sync.get({
+        filterMode: 'hide',
+        allowedRatios: [],
+        customRatios: [],
+        tolerance: 5,
+        filterActive: true
+    });
+
+    // Set filter mode
+    document.querySelector(`input[name="filterMode"][value="${settings.filterMode}"]`).checked = true;
+
+    // Set allowed ratios
+    settings.allowedRatios.forEach(ratio => {
+        const checkbox = document.querySelector(`input[data-value="${ratio}"]`);
+        if (checkbox) {
+            checkbox.checked = true;
+        }
+    });
+
+    // Set custom ratios
+    displayCustomRatios(settings.customRatios);
+
+    // Set tolerance
+    document.getElementById('tolerance').value = settings.tolerance;
+    document.getElementById('toleranceValue').textContent = `${settings.tolerance}%`;
+
+    // Set filter active state
+    updateToggleButton(settings.filterActive);
+}
+
+// Setup event listeners
+function setupEventListeners() {
+    // Filter mode changes
+    document.querySelectorAll('input[name="filterMode"]').forEach(radio => {
+        radio.addEventListener('change', saveAndApplySettings);
+    });
+
+    // Ratio checkbox changes
+    document.querySelectorAll('.ratio-option input[type="checkbox"]').forEach(checkbox => {
+        checkbox.addEventListener('change', saveAndApplySettings);
+    });
+
+    // Tolerance slider
+    document.getElementById('tolerance').addEventListener('input', (e) => {
+        document.getElementById('toleranceValue').textContent = `${e.target.value}%`;
+    });
+    document.getElementById('tolerance').addEventListener('change', saveAndApplySettings);
+
+    // Custom ratio
+    document.getElementById('addCustom').addEventListener('click', addCustomRatio);
+    document.getElementById('customWidth').addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') addCustomRatio();
+    });
+    document.getElementById('customHeight').addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') addCustomRatio();
+    });
+
+    // Toggle filter
+    document.getElementById('toggleFilter').addEventListener('click', toggleFilter);
+
+    // Save settings button
+    document.getElementById('saveSettings').addEventListener('click', saveAndApplySettings);
+}
+
+// Add custom ratio
+function addCustomRatio() {
+    const width = parseInt(document.getElementById('customWidth').value);
+    const height = parseInt(document.getElementById('customHeight').value);
+
+    if (!width || !height || width <= 0 || height <= 0) {
+        showStatus('Please enter valid width and height values', 'error');
+        return;
+    }
+
+    const ratio = width / height;
+    const ratioString = `${width}:${height}`;
+
+    chrome.storage.sync.get(['customRatios'], (result) => {
+        const customRatios = result.customRatios || [];
+        
+        // Check if ratio already exists
+        if (customRatios.some(r => r.string === ratioString)) {
+            showStatus('This ratio already exists', 'error');
+            return;
+        }
+
+        customRatios.push({ string: ratioString, value: ratio });
+        
+        chrome.storage.sync.set({ customRatios }, () => {
+            displayCustomRatios(customRatios);
+            document.getElementById('customWidth').value = '';
+            document.getElementById('customHeight').value = '';
+            saveAndApplySettings();
+            showStatus('Custom ratio added', 'success');
+        });
+    });
+}
+
+// Display custom ratios
+function displayCustomRatios(customRatios) {
+    const container = document.getElementById('customRatiosList');
+    container.innerHTML = '';
+
+    customRatios.forEach((ratio, index) => {
+        const div = document.createElement('div');
+        div.className = 'custom-ratio-item';
+        div.innerHTML = `
+            <label class="ratio-option">
+                <input type="checkbox" data-custom="true" data-value="${ratio.value}" checked>
+                <span>${ratio.string}</span>
+            </label>
+            <button class="remove-btn" data-index="${index}">×</button>
+        `;
+        container.appendChild(div);
+
+        // Add event listeners
+        div.querySelector('input[type="checkbox"]').addEventListener('change', saveAndApplySettings);
+        div.querySelector('.remove-btn').addEventListener('click', () => removeCustomRatio(index));
+    });
+}
+
+// Remove custom ratio
+function removeCustomRatio(index) {
+    chrome.storage.sync.get(['customRatios'], (result) => {
+        const customRatios = result.customRatios || [];
+        customRatios.splice(index, 1);
+        
+        chrome.storage.sync.set({ customRatios }, () => {
+            displayCustomRatios(customRatios);
+            saveAndApplySettings();
+            showStatus('Custom ratio removed', 'success');
+        });
+    });
+}
+
+// Toggle filter on/off
+async function toggleFilter() {
+    const button = document.getElementById('toggleFilter');
+    const isActive = button.classList.contains('active');
+    const newState = !isActive;
+
+    await chrome.storage.sync.set({ filterActive: newState });
+    updateToggleButton(newState);
+    
+    // Send message to content script
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (tab && tab.url && tab.url.includes('pinterest.com')) {
+        chrome.tabs.sendMessage(tab.id, { 
+            action: 'toggleFilter', 
+            active: newState 
+        });
+    }
+
+    showStatus(newState ? 'Filter activated' : 'Filter deactivated', 'success');
+}
+
+// Update toggle button appearance
+function updateToggleButton(isActive) {
+    const button = document.getElementById('toggleFilter');
+    if (isActive) {
+        button.classList.add('active');
+        button.textContent = 'Filter Active';
+    } else {
+        button.classList.remove('active');
+        button.textContent = 'Filter Inactive';
+    }
+}
+
+// Save and apply settings
+async function saveAndApplySettings() {
+    const filterMode = document.querySelector('input[name="filterMode"]:checked').value;
+    const tolerance = parseInt(document.getElementById('tolerance').value);
+    
+    // Get all checked ratios
+    const allowedRatios = [];
+    document.querySelectorAll('.ratio-option input[type="checkbox"]:checked').forEach(checkbox => {
+        allowedRatios.push(parseFloat(checkbox.dataset.value));
+    });
+
+    // Get filter active state
+    const filterActive = document.getElementById('toggleFilter').classList.contains('active');
+
+    // Save to storage
+    await chrome.storage.sync.set({
+        filterMode,
+        allowedRatios,
+        tolerance,
+        filterActive
+    });
+
+    // Apply to current tab
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (tab && tab.url && tab.url.includes('pinterest.com')) {
+        chrome.tabs.sendMessage(tab.id, { 
+            action: 'updateSettings',
+            settings: {
+                filterMode,
+                allowedRatios,
+                tolerance,
+                filterActive
+            }
+        });
+    }
+
+    showStatus('Settings saved', 'success');
+}
+
+// Show status message
+function showStatus(message, type = 'success') {
+    const status = document.getElementById('status');
+    status.textContent = message;
+    status.className = `status ${type}`;
+    status.style.display = 'block';
+
+    setTimeout(() => {
+        status.style.display = 'none';
+    }, 3000);
+}

--- a/pinterest-aspect-ratio-filter/push-to-github.sh
+++ b/pinterest-aspect-ratio-filter/push-to-github.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Replace YOUR_USERNAME with your actual GitHub username
+GITHUB_USERNAME="YOUR_USERNAME"
+REPO_NAME="pinterest-aspect-ratio-filter"
+
+echo "This script will push the Pinterest Aspect Ratio Filter to GitHub"
+echo "================================================"
+echo ""
+echo "Please make sure you have:"
+echo "1. Created a new repository on GitHub named: $REPO_NAME"
+echo "2. Replaced YOUR_USERNAME in this script with your GitHub username"
+echo ""
+read -p "Enter your GitHub username: " GITHUB_USERNAME
+
+# Add the remote origin
+echo "Adding remote origin..."
+git remote add origin "https://github.com/${GITHUB_USERNAME}/${REPO_NAME}.git"
+
+# Push to GitHub
+echo "Pushing to GitHub..."
+git push -u origin main
+
+echo ""
+echo "✅ Successfully pushed to GitHub!"
+echo "Repository URL: https://github.com/${GITHUB_USERNAME}/${REPO_NAME}"
+echo ""
+echo "Next steps:"
+echo "1. Visit your repository on GitHub"
+echo "2. Add topics like: chrome-extension, pinterest, image-filter, aspect-ratio"
+echo "3. Consider adding a LICENSE file (MIT recommended)"
+echo "4. You can publish to Chrome Web Store if desired"


### PR DESCRIPTION
Adds a Chrome extension to filter Pinterest images by aspect ratio, allowing users to hide, blur, or dim non-matching images based on user-defined preferences.

---
<a href="https://cursor.com/background-agent?bcId=bc-f49dbd32-0b53-490d-aa3d-4ee01ab247a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f49dbd32-0b53-490d-aa3d-4ee01ab247a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

